### PR TITLE
Add InfluxDB ingestion and simple dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>NMON InfluxDB Dashboard</title>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+<h1>NMON InfluxDB Dashboard</h1>
+<div>
+  <label for="lpar">LPAR:</label>
+  <select id="lpar"></select>
+  <label for="start">Start:</label>
+  <input type="datetime-local" id="start" />
+  <label for="end">End:</label>
+  <input type="datetime-local" id="end" />
+  <button onclick="loadData()">Load</button>
+</div>
+<div id="cpu_chart" style="height:400px;"></div>
+<script>
+const bucket = 'nmon';
+async function init(){
+  const lpars = await fetch(`/lpars?bucket=${bucket}`).then(r=>r.json());
+  const sel = document.getElementById('lpar');
+  lpars.forEach(l=>{const o=document.createElement('option');o.value=l;o.text=l;sel.appendChild(o);});
+}
+async function loadData(){
+  const lpar=document.getElementById('lpar').value;
+  const start=document.getElementById('start').value;
+  const end=document.getElementById('end').value;
+  const flux = `from(bucket:"${bucket}") |> range(start: ${start?`time(v:"${start}Z")`:"-1h"}, stop: ${end?`time(v:"${end}Z")`:"now()"}) |> filter(fn:(r)=>r["lpar"]=="${lpar}" and r._measurement=="CPU_ALL")`;
+  const data = await fetch('/query?q='+encodeURIComponent(flux)).then(r=>r.json());
+  const times = data.map(d=>d._time);
+  const user = data.filter(d=>d._field=='User%').map(d=>d._value);
+  const sys = data.filter(d=>d._field=='Sys%').map(d=>d._value);
+  const trace1={x:times,y:user,name:'User%',type:'scatter'};
+  const trace2={x:times,y:sys,name:'Sys%',type:'scatter'};
+  Plotly.newPlot('cpu_chart',[trace1,trace2]);
+}
+init();
+</script>
+</body>
+</html>

--- a/nmon2influx.py
+++ b/nmon2influx.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""NMON to InfluxDB ingester and API proxy."""
+
+import argparse
+import glob
+import os
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from influxdb_client import InfluxDBClient, Point, WritePrecision
+from influxdb_client.client.write_api import SYNCHRONOUS
+import uvicorn
+
+# ----------------------------------------------------------------------
+# Generic NMON parser -> list of InfluxDB points
+# ----------------------------------------------------------------------
+
+def parse_nmon_file(path: str) -> Tuple[str, str, List[Dict]]:
+    """Return (lpar, frame, points)."""
+    zzzz: Dict[str, datetime] = {}
+    headers: Dict[str, List[str]] = {}
+    points: List[Dict] = []
+    lpar = None
+    frame = None
+
+    with open(path, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(',')
+            key = parts[0]
+            if key == 'AAA' and len(parts) > 2:
+                if parts[1] == 'NodeName':
+                    lpar = parts[2]
+                elif parts[1] == 'SerialNumber':
+                    frame = parts[2]
+                continue
+            if key == 'ZZZZ' and len(parts) > 3:
+                tag = parts[1]
+                try:
+                    ts = datetime.strptime(f"{parts[3]} {parts[2]}", "%d-%b-%Y %H:%M:%S")
+                    zzzz[tag] = ts
+                except Exception:
+                    pass
+                continue
+            if len(parts) > 1 and not parts[1].startswith('T'):
+                headers[key] = parts[2:]
+                continue
+            if len(parts) > 1 and parts[1].startswith('T'):
+                tag = parts[1]
+                ts = zzzz.get(tag)
+                if not ts:
+                    continue
+                measurement = key
+                header = headers.get(measurement)
+                if not header:
+                    continue
+                fields = {}
+                for idx, col in enumerate(header):
+                    if idx + 2 < len(parts):
+                        try:
+                            fields[col] = float(parts[idx+2])
+                        except Exception:
+                            fields[col] = None
+                point = {
+                    'measurement': measurement,
+                    'tags': {'lpar': lpar or '', 'frame': frame or ''},
+                    'fields': fields,
+                    'time': ts
+                }
+                points.append(point)
+                continue
+    return lpar or '', frame or '', points
+
+# ----------------------------------------------------------------------
+# Ingestion
+# ----------------------------------------------------------------------
+
+def ingest_dir(input_dir: str, url: str, token: str, org: str, bucket: str):
+    client = InfluxDBClient(url=url, token=token, org=org)
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+    nmon_files = glob.glob(os.path.join(input_dir, '*.nmon'))
+    if not nmon_files:
+        print(f'No .nmon files found in {input_dir}')
+        return
+    for fp in nmon_files:
+        lpar, frame, points = parse_nmon_file(fp)
+        records = []
+        for p in points:
+            point = Point(p['measurement'])
+            point.time(p['time'], WritePrecision.NS)
+            for k, v in p['tags'].items():
+                point.tag(k, v)
+            for k, v in p['fields'].items():
+                if v is not None:
+                    point.field(k, v)
+            records.append(point)
+        if records:
+            write_api.write(bucket=bucket, record=records)
+            print(f'Ingested {len(records)} points from {os.path.basename(fp)}')
+    client.close()
+
+# ----------------------------------------------------------------------
+# FastAPI proxy
+# ----------------------------------------------------------------------
+app = FastAPI()
+client_holder = {'client': None}
+
+@app.on_event('startup')
+def startup_event():
+    url = app.state.influx_url
+    token = app.state.influx_token
+    org = app.state.influx_org
+    client_holder['client'] = InfluxDBClient(url=url, token=token, org=org)
+
+@app.on_event('shutdown')
+def shutdown_event():
+    if client_holder['client']:
+        client_holder['client'].close()
+
+@app.get('/lpars')
+def list_lpars(bucket: str):
+    query = f"import \"influxdata/influxdb/schema\"\n schema.tagValues(bucket: \"{bucket}\", tag: \"lpar\")"
+    result = client_holder['client'].query_api().query(org=app.state.influx_org, query=query)
+    values = [r.get_value() for table in result for r in table.records]
+    return JSONResponse(values)
+
+@app.get('/frames')
+def list_frames(bucket: str):
+    query = f"import \"influxdata/influxdb/schema\"\n schema.tagValues(bucket: \"{bucket}\", tag: \"frame\")"
+    result = client_holder['client'].query_api().query(org=app.state.influx_org, query=query)
+    values = [r.get_value() for table in result for r in table.records]
+    return JSONResponse(values)
+
+@app.get('/query')
+def run_query(q: str):
+    try:
+        result = client_holder['client'].query_api().query(org=app.state.influx_org, query=q)
+        data = []
+        for table in result:
+            for record in table.records:
+                data.append(record.values)
+        return JSONResponse(data)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+# ----------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description='NMON to InfluxDB tool')
+    sub = parser.add_subparsers(dest='command')
+
+    ing = sub.add_parser('ingest', help='Ingest NMON files to InfluxDB')
+    ing.add_argument('--input-dir', required=True)
+    ing.add_argument('--url', required=True)
+    ing.add_argument('--token', required=True)
+    ing.add_argument('--org', required=True)
+    ing.add_argument('--bucket', required=True)
+
+    api = sub.add_parser('api', help='Run FastAPI proxy server')
+    api.add_argument('--host', default='0.0.0.0')
+    api.add_argument('--port', type=int, default=8000)
+    api.add_argument('--url', required=True)
+    api.add_argument('--token', required=True)
+    api.add_argument('--org', required=True)
+
+    args = parser.parse_args()
+
+    if args.command == 'ingest':
+        ingest_dir(args.input_dir, args.url, args.token, args.org, args.bucket)
+    elif args.command == 'api':
+        app.state.influx_url = args.url
+        app.state.influx_token = args.token
+        app.state.influx_org = args.org
+        uvicorn.run(app, host=args.host, port=args.port)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+influxdb-client


### PR DESCRIPTION
## Summary
- add `nmon2influx.py` with parser, InfluxDB ingestion and FastAPI proxy
- add basic Plotly dashboard `index.html` fetching data from the API
- add requirements.txt with dependencies

## Testing
- `python3 -m py_compile nmon2influx.py`

------
https://chatgpt.com/codex/tasks/task_e_686ba33844208320b36866b342972c62